### PR TITLE
Gauntlet Submission: Quinn Kastle

### DIFF
--- a/src/data/gauntlet/index.yml
+++ b/src/data/gauntlet/index.yml
@@ -1,1 +1,4 @@
-{}
+- name: Quinn Kastle
+  time: '1:42.48'
+  position: back
+  stroke: 27


### PR DESCRIPTION
New gauntlet entry submitted via website:

- Name: Quinn Kastle
- Time: 1:42.48
- Position: back
- Stroke Rate: 27